### PR TITLE
Adding Passive Port Range

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ RUN mkdir /ftp_root
 RUN mkdir /ftp_root/nobody
 RUN mkdir /ftp_root/user
 
-EXPOSE 21
+EXPOSE 20 21
 
 CMD python ftpd.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7.11-slim
 
-MAINTAINER MidAmericaCareers "simon@midamericacareers.com"
+MAINTAINER Andriy Kogut "kogut.andriy@gmail.com"
 
 COPY . /app
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:2.7.11-slim
 
-MAINTAINER Andriy Kogut "kogut.andriy@gmail.com"
+MAINTAINER MidAmericaCareers "simon@midamericacareers.com"
 
 COPY . /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ ftp>
 ```
 docker run -it --rm -p 21:21 akogut/docker-pyftpdlib python ftpd.py -h
 usage: ftpd.py [-h] [--user USER] [--password PASSWORD] [--host HOST]
-               [--port PORT] [--anon]
+               [--port PORT] [--passive PASSIVE] [--anon]
 
 optional arguments:
   -h, --help           show this help message and exit
@@ -38,5 +38,6 @@ optional arguments:
   --password PASSWORD  Password for FTP user. (default: password)
   --host HOST
   --port PORT
-  --anon               Allow anonymous acess (default: False)
+  --passive PASSIVE    Range of passive ports (default: 3000-3010)
+  --anon               Allow anonymous access (default: False)
 ```

--- a/ftpd.py
+++ b/ftpd.py
@@ -8,7 +8,7 @@ from pyftpdlib.servers import FTPServer
 FTP_ROOT = '/ftp_root'
 
 
-def run_ftpd(user, password, host, port, anon):
+def run_ftpd(user, password, host, port, passive, anon):
     user_dir = os.path.join(FTP_ROOT, user)
     if not os.path.isdir(user_dir):
         os.mkdir(user_dir)
@@ -20,7 +20,9 @@ def run_ftpd(user, password, host, port, anon):
     handler = FTPHandler
     handler.authorizer = authorizer
     handler.permit_foreign_addresses = True
-    handler.passive_ports = range(3000, 4000)
+    
+    passive_ports = map(int, passive.split('-'))
+    handler.passive_ports = range(passive_ports[0], passive_ports[1])
 
     server = FTPServer((host, port), handler)
     server.serve_forever()
@@ -37,6 +39,7 @@ def main():
                         help="Password for FTP user.")
     parser.add_argument('--host', default='0.0.0.0')
     parser.add_argument('--port', type=int, default=21)
+    parser.add_argument('--passive', default='3000-3010')
     parser.add_argument('--anon', action='store_true',
                         help="Allow anonymous acess")
     args = parser.parse_args()

--- a/ftpd.py
+++ b/ftpd.py
@@ -20,6 +20,7 @@ def run_ftpd(user, password, host, port, anon):
     handler = FTPHandler
     handler.authorizer = authorizer
     handler.permit_foreign_addresses = True
+    handler.passive_ports = range(3000, 4000)
 
     server = FTPServer((host, port), handler)
     server.serve_forever()

--- a/ftpd.py
+++ b/ftpd.py
@@ -39,9 +39,10 @@ def main():
                         help="Password for FTP user.")
     parser.add_argument('--host', default='0.0.0.0')
     parser.add_argument('--port', type=int, default=21)
-    parser.add_argument('--passive', default='3000-3010')
+    parser.add_argument('--passive', default='3000-3010',
+                        help="Range of passive ports")
     parser.add_argument('--anon', action='store_true',
-                        help="Allow anonymous acess")
+                        help="Allow anonymous access")
     args = parser.parse_args()
     run_ftpd(**vars(args))
 


### PR DESCRIPTION
Hi,

When I was using the image for local testing, I found that in order to enable passive mode, we need to specify the passive port ranges in the handler, that way we can set up port mapping inside Docker to open just the right # of ports for FTP data transfer in passive mode.

Creating this PR so you can take the changes in.